### PR TITLE
Custom error codes should fall through

### DIFF
--- a/lib/postgrex/error_code.ex
+++ b/lib/postgrex/error_code.ex
@@ -36,6 +36,7 @@ defmodule Postgrex.ErrorCode do
     [{^code, name}] = errcodes
     def code_to_name(unquote(code)), do: unquote(name)
   end
+  def code_to_name(code), do: code
 
   @doc ~S"""
   Translates a Postgres error name into a list of possible codes.


### PR DESCRIPTION
I'm using postgrex with some plpgsql functions that raise a custom error. The code to string conversion should fall through to return the code if the code is not in the list of errors.
